### PR TITLE
Add .factorypath to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ MANIFEST.MF
 .idea/
 .pmd
 .checkstyle
+.factorypath
 
 # Log #
 #######


### PR DESCRIPTION
Adding .factorypath to gitignore to minimize the risk of comminting an unuseful file.